### PR TITLE
Update MVP.md

### DIFF
--- a/MVP.md
+++ b/MVP.md
@@ -1,6 +1,7 @@
 # Introduction
-LexDAO has been working for the last two years to try to move into a stable and long-term solution for managing its membership.  Our specifications have been developed in the [Readme.md File](https://github.com/cimplylimited/LexDAO-MembershipToken-2023) to determine the base needs for operating a pay-for-membership ecosystem that brings together networks of professionals with non-transferrable "light" credentials.  It is easy to take for granted how simple it is to deploy memberships in today's day in age using conventional methods.  After all, membership organizations are not a new concept.  So one might wonder "how could it take this long to solve something so basic?"  
+LexDAO has been working for the last two years to try to move into a stable and long-term solution for managing its membership.  Our specifications have been developed in the [Readme](https://github.com/cimplylimited/LexDAO-MembershipToken-2023) to determine the base needs for operating a pay-for-membership ecosystem that brings together networks of professionals with non-transferrable "light" credentials.  It is easy to take for granted how simple it is to deploy memberships in today's day in age using conventional methods.  After all, membership organizations are not a new concept.  So one might wonder "how could it take this long to solve something so basic?"  
 
+<details><summary><b>TL;DR</b> we insource to <a href="https://unlock-protocol.com/">Unlock Protocol</a></summary>
 We have taken extraordinary care to try to find solutions that are complete for the basic specifications we deemed critical to effectively deploying a membership protocol for our organization.  We operate a web3 native organization and have attempted to apply some of the core concepts around tokens and blockchains to organize and manage a DAO structure in a smart and thoughtful manner.  Therefore, we have gone through a painful process of not "settling" for incomplete solutions, possibly to a fault.  
 
 In our discovery process, we've found that the concepts around NFTs fits so naturally to the idea of a validated membership card and yet the web3 ecosystem remains incredibly nascent and difficult to configure for such a baseline use case.  Most solutions and options are fundamentally incomplete.  There are a number of providers and solutions out there that seem to get most of the way there, but somehow manage to fall short of any number of critical needs which might include payment options, metadata configuration, permission structures, chain compatibility, among others.  
@@ -11,3 +12,27 @@ In all of our investigations to-date, we have discovered one protocol which has 
 
 The best solution we have found is a provider known as [Unlock Protocol](https://unlock-protocol.com/) which offers ERC-721 tokens that are fully configurable and can be implemented on a variety of common L1 and L2 blockchains.  From a pure functional perspective
 
+</details>
+
+# Problem = Signal 2 Noise Ratio
+
+<details><summary>The tokenomics of LexDAO are simple but the interactions are subtle:</summary>
+1. mmmber - annual fixed subscriptionin fiat but payable in stablecoins;
+   - working for membership - a loosely pegged conversion from base membership to LXCHAT, a timebank
+   - this timebank represents ~15 hrs of sweat as in-kind contribution in lieu of the annual membership subscription
+   - it is arguable whether these l'externs should have access to all guild channels given the semi-confidential nature of some projects but conceptually they have all access to the same platforms members have (discord, hackMD, github, etc)
+2. guest pass (discord only) - as a privilege members are permitted to issue guest passes for public to participate in special events within discord such as hackathons or study groups
+   - however most guest passes are automatically granted 4 wks via #introduction or by following the decision tree triage in #find-a-lawyer
+   - these guest passes are expoential backdown which means the 2nd renewal is at half the time
+   - they are automatically renewed if they submit a common which is "liked" by a LEETHodler or member performing the druid role (guest concierage)
+   - however, the same druids have power to revoke such guest privileges upon spam, behaviour contrary to community norms or upon complaint by regular member but which is appealable at @Ops total discretion
+3. LEETHodlers are a special case as there were certain historical discussions which grandfathered in certain privileges and retained as result of legacy (beware of cryptowizards for theur anger is slow but revenge is subtle.
+<!-- if people think this is unfair try growing a community of <40 through cryptowinter via unpaid vounteers sacrificing time as busy professionals, then come back to me -->
+</details>
+
+# solutiion = Fostering Interaction
+
+In addition to `CRED` which is the paidup membership token, we use sourceCred to
+1. measure github activity
+2. /tbd\ passively monitor discord reactions as proxy for "oreference"voting (temp polls etc) on opt-in basis
+3. /tbd\ connect the different summon circles for l'externs. We send rogues on quests to other servers and whlist we have ambassaDAOs (formal) or members at other DAOs, it is simply impossible to overwatch all of them manually. Hence as opt-in service, we request l'externs on quests to alter their display name to append`| Le⚔️DAO` so `lexy` our bot-in-training can recognise you and come running to collect evidence of abuse. This is definitely in alpha-testing.


### PR DESCRIPTION
Cimply, i've highlighted the direction which I think is compatible with unlock protocol, and the use of sourceCred to replace onerous quarterly or weekly voting with low-cost but weak signals via discobot likes/gifts. 

The actual discobot `lexy` is yet to be grown so it is a medium term goal but the point is to send l'externs on quests to other DAOs and in return standup guests from say TokenEngineering Communiy or Bankless in rogue 1.x cross-skilling (legal philosophy, basic e-contracts etc)